### PR TITLE
Provide resolution to git-annex installation via DEBIAN_FRONTEND: noninteractive env var

### DIFF
--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -58,9 +58,10 @@ jobs:
           python-version: 3.11
       
       - name: Install Datalad
-        uses: neuronets/datalad-action/install@main
-        with:
-          pip_install: datalad-osf
+        run: pip install datalad-installer
+#        uses: neuronets/datalad-action/install@main
+#        with:
+#          pip_install: datalad-osf
 
       - name: print datalad version
         run: |

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -58,14 +58,21 @@ jobs:
           python-version: 3.11
       
       - name: Install Datalad
-        run: pip install datalad-installer
+        run:
+          |
+          pip install datalad-installer
+          pip list
+          datalad-installer git-annex -m datalad/git-annex:release
+          git config --global filter.annex.process "git-annex filter-process"
+          pip install datalad
+          datalad --version
 #        uses: neuronets/datalad-action/install@main
 #        with:
 #          pip_install: datalad-osf
 
-      - name: print datalad version
-        run: |
-          datalad --version
+#      - name: print datalad version
+#        run: |
+#          datalad --version
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -58,11 +58,14 @@ jobs:
           python-version: 3.11
       
       - name: Install Datalad
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run:
           |
           pip install datalad-installer
           pip list
-          datalad-installer git-annex -m datalad/git-annex:release
+          sudo apt-get update
+          sudo apt-get install -y git-annex
           git config --global filter.annex.process "git-annex filter-process"
           pip install datalad
           datalad --version

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -70,9 +70,9 @@ jobs:
 #        with:
 #          pip_install: datalad-osf
 
-#      - name: print datalad version
-#        run: |
-#          datalad --version
+      - name: print datalad version
+        run: |
+          datalad --version
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -63,12 +63,10 @@ jobs:
         run:
           |
           pip install datalad-installer
-          pip list
           sudo apt-get update
           sudo apt-get install -y git-annex
           git config --global filter.annex.process "git-annex filter-process"
           pip install datalad
-          datalad --version
 #        uses: neuronets/datalad-action/install@main
 #        with:
 #          pip_install: datalad-osf


### PR DESCRIPTION
@hvgazula -- Take a peek here and let me know if this resolves your concern. Seems `datalad` and `git-annex` are both there.

I think the issue here was actually that the `git-annex` installation required manual input to proceed; however, in the GitHub Runner everything is programatic, so an EOF error occurs. Thus, running in non-interactive mode, and instructing the runner to say "yes" to everything via `-y`, all becomes well 😄 

I put this into `Draft` mode since we can clean up more here if this is sufficient. Let me know -- thanks